### PR TITLE
fixed emhash8::find(key) ambiguous call

### DIFF
--- a/hash_table8.hpp
+++ b/hash_table8.hpp
@@ -518,7 +518,7 @@ public:
 
     // ------------------------------------------------------------
     template<typename K=KeyT>
-    iterator find(const KeyT& key) noexcept
+    iterator find(const K& key) noexcept
     {
         return {this, find_filled_slot(key)};
     }


### PR DESCRIPTION
Signed-off-by: GuoXH <gz_shines@msn.com>

修正 `/hashmap-benchmark/bench/time_hash_map` 的这个错误：

```text
/home/git/hashmap-benchmark/bench/time_hash_map/time_hash_map_func.hpp:26:47: error: call to member function 'find' is ambiguous
        r ^= static_cast<std::size_t>(hashmap.find(indices[i]) != hashmap.end());
```

这里 indices[i] 不是KeyT，而是可以被KeyT的构造函数 KeyT(indices[i]) 构造的类型，所以这里应该统一使用 const K& key，不然会造成"暧昧"call，编译器不知道选择哪个版本。