### PR TITLE
fix a compile error

### DIFF
--- a/hash_table8.hpp
+++ b/hash_table8.hpp
@@ -1660,7 +1660,7 @@ one-way search strategy.
 
 #if EMH_WYHASH_HASH
     //#define WYHASH_CONDOM 1
-    inline uint64_t wymix(uint64_t A, uint64_t B)
+    inline static uint64_t wymix(uint64_t A, uint64_t B)
     {
 #if defined(__SIZEOF_INT128__)
         __uint128_t r = A; r *= B;


### PR DESCRIPTION
With `#define EMH_WYHASH_HASH 1` enabled, the static function `wyhashstr` calls `wymix`.
However, `wymix` is not declared as `static`, causing a compile error.
This commit adds `static` into `wymix`.