### PR TITLE
Fix minor warnings in hash_table7.hpp

### DIFF
--- a/hash_table7.hpp
+++ b/hash_table7.hpp
@@ -276,9 +276,12 @@ struct entry {
 
     entry& operator = (const entry& rhs)
     {
-        second = rhs.second;
-        bucket = rhs.bucket;
-        first  = rhs.first;
+        if (this != &rhs) // not a self-assignment
+        {
+            second = rhs.second;
+            bucket = rhs.bucket;
+            first  = rhs.first;
+        }
         return *this;
     }
 
@@ -358,7 +361,7 @@ public:
 #if EMH_ITER_SAFE
         iterator(const htype* hash_map, size_type bucket) : _map(hash_map), _bucket(bucket) { init(); }
 #else
-        iterator(const htype* hash_map, size_type bucket) : _map(hash_map), _bucket(bucket) { _from = size_type(-1); }
+        iterator(const htype* hash_map, size_type bucket) : _map(hash_map), _bucket(bucket), _bmask(0) { _from = size_type(-1); }
 #endif
 
         void init()
@@ -463,7 +466,7 @@ public:
 #if EMH_ITER_SAFE
         const_iterator(const htype* hash_map, size_type bucket) : _map(hash_map), _bucket(bucket) { init(); }
 #else
-        const_iterator(const htype* hash_map, size_type bucket) : _map(hash_map), _bucket(bucket) { _from = size_type(-1); }
+        const_iterator(const htype* hash_map, size_type bucket) : _map(hash_map), _bucket(bucket), _bmask(0) { _from = size_type(-1); }
 #endif
 
         void init()


### PR DESCRIPTION
Fix warnings: uninitialized field and unsafe assignment operator