### PR TITLE
fix -Wsign-compare

### DIFF
--- a/hash_set8.hpp
+++ b/hash_set8.hpp
@@ -913,7 +913,7 @@ public:
 
         uint32_t num_buckets = _num_filled > (1u << 16) ? (1u << 16) : 4u;
         while (num_buckets < required_buckets) { num_buckets *= 2; }
-        assert(num_buckets < max_size());
+        assert(num_buckets < (uint64_t)max_size());
 
 #if EMH_REHASH_LOG
         auto last = _last;

--- a/hash_table5.hpp
+++ b/hash_table5.hpp
@@ -1385,7 +1385,7 @@ public:
         //if (sizeof(KeyT) < sizeof(size_type) && buckets >= (1ul << (2 * 8)))
         //    buckets = 2ul << (sizeof(KeyT) * 8);
 
-        assert(buckets < max_size() && buckets > _num_filled);
+        assert(buckets < (uint64_t)max_size() && buckets > (uint64_t)_num_filled);
 
         auto num_buckets = (size_type)buckets;
         auto old_num_filled  = _num_filled;

--- a/hash_table6.hpp
+++ b/hash_table6.hpp
@@ -1255,7 +1255,7 @@ public:
         //if (sizeof(KeyT) < sizeof(size_type) && buckets >= (1ul << (2 * 8)))
         //    buckets = 2ul << (sizeof(KeyT) * 8);
 
-        assert(buckets < max_size() && buckets > _num_filled);
+        assert(buckets < (uint64_t)max_size() && buckets > (uint64_t)_num_filled);
         //assert(num_buckets == (2 << CTZ(required_buckets)));
 #endif
 

--- a/hash_table7.hpp
+++ b/hash_table7.hpp
@@ -1378,7 +1378,7 @@ public:
         //if (sizeof(KeyT) < sizeof(size_type) && buckets > (1ul << (sizeof(uint16_t) * 8)))
         //    buckets = 2ul << (sizeof(KeyT) * 8);
 
-        assert(buckets < max_size() && buckets > _num_filled);
+        assert(buckets < (uint64_t)max_size() && buckets > (uint64_t)_num_filled);
         //TODO: throwOverflowError
 
         auto num_buckets = (size_type)buckets;

--- a/hash_table8.hpp
+++ b/hash_table8.hpp
@@ -1173,7 +1173,7 @@ public:
         if (required_buckets < _num_filled)
             return;
 
-        assert(required_buckets < max_size());
+        assert(required_buckets < (uint64_t)max_size());
         auto num_buckets = _num_filled > (1u << 16) ? (1u << 16) : 4u;
         while (num_buckets < required_buckets) { num_buckets *= 2; }
 #if EMH_SAVE_MEM


### PR DESCRIPTION
Fix some compiler warnings:

```
hash_table5.hpp:1388:24: warning: comparison of integer expressions of different signedness: ‘uint64_t’ {aka ‘long unsigned int’} and ‘emhash5::size_type’ {aka ‘int’} [-Wsign-compare]
 1388 |         assert(buckets < max_size() && buckets > _num_filled);
      |                ~~~~~~~~^~~~~~~~~~~~
hash_table5.hpp:1388:48: warning: comparison of integer expressions of different signedness: ‘uint64_t’ {aka ‘long unsigned int’} and ‘emhash5::size_type’ {aka ‘int’} [-Wsign-compare]
 1388 |         assert(buckets < max_size() && buckets > _num_filled);
      |                                        ~~~~~~~~^~~~~~~~~~~~~
```