### PR TITLE
fix hash_function() and key_eq()

### DIFF
--- a/hash_set2.hpp
+++ b/hash_set2.hpp
@@ -405,12 +405,12 @@ public:
         return static_cast<float>(_num_filled) / (_num_buckets + 0.01f);
     }
 
-    HashT& hash_function() const
+    const HashT& hash_function() const
     {
         return _hasher;
     }
 
-    EqT& key_eq() const
+    const EqT& key_eq() const
     {
         return _eq;
     }

--- a/hash_set3.hpp
+++ b/hash_set3.hpp
@@ -420,7 +420,7 @@ public:
         return _hasher;
     }
 
-    EqT& key_eq() const
+    const EqT& key_eq() const
     {
         return _eq;
     }

--- a/hash_set4.hpp
+++ b/hash_set4.hpp
@@ -490,12 +490,12 @@ public:
         return static_cast<float>(_num_filled) / (_num_buckets + 0.01f);
     }
 
-    HashT& hash_function()
+    const HashT& hash_function()
     {
         return _hasher;
     }
 
-    EqT& key_eq() const
+    const EqT& key_eq() const
     {
         return _eq;
     }

--- a/hash_set8.hpp
+++ b/hash_set8.hpp
@@ -378,8 +378,8 @@ public:
     /// Returns average number of elements per bucket.
     float load_factor() const { return static_cast<float>(_num_filled) / (_mask + 1); }
 
-    HashT& hash_function() const { return _hasher; }
-    EqT& key_eq() const { return _eq; }
+    const HashT& hash_function() const { return _hasher; }
+    const EqT& key_eq() const { return _eq; }
 
     void max_load_factor(float mlf)
     {

--- a/hash_table6.hpp
+++ b/hash_table6.hpp
@@ -676,8 +676,8 @@ public:
     size_type bucket_count() const { return _mask + 1; }
     float load_factor() const { return static_cast<float>(_num_filled) / ((float)_mask + 1.0f); }
 
-    HashT& hash_function() const { return _hasher; }
-    EqT& key_eq() const { return _eq; }
+    const HashT& hash_function() const { return _hasher; }
+    const EqT& key_eq() const { return _eq; }
 
     void max_load_factor(float mlf)
     {

--- a/hash_table7.hpp
+++ b/hash_table7.hpp
@@ -765,8 +765,8 @@ public:
     inline size_type bucket_count() const { return _num_buckets; }
     inline float load_factor() const { return ((float)_num_filled) / ((float)_mask + 1.0f); }
 
-    inline HashT& hash_function() const { return _hasher; }
-    inline EqT& key_eq() const { return _eq; }
+    inline const HashT& hash_function() const { return _hasher; }
+    inline const EqT& key_eq() const { return _eq; }
 
     inline void max_load_factor(float mlf)
     {

--- a/hash_table8.hpp
+++ b/hash_table8.hpp
@@ -417,7 +417,7 @@ public:
     float load_factor() const { return static_cast<float>(_num_filled) / ((float)_mask + 1.0f); }
 
     const HashT& hash_function() const { return _hasher; }
-    EqT& key_eq() const { return _eq; }
+    const EqT& key_eq() const { return _eq; }
 
     void max_load_factor(float mlf)
     {


### PR DESCRIPTION
This is a follow up for #57.

![Snipaste_2025-03-24_14-19-06](https://github.com/user-attachments/assets/b6c4908d-21c2-41ac-89b7-e883e4cb4180)

By the way, `std::unordered_map` returns values not references so that it avoids this kind of errors. If emhash took the same approach it could lead to compatibility issues, so I decided to add the `const` qualifier first.