### PR TITLE
CMake: Add install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ install(EXPORT emhash-targets
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/emhash
 )
 
-configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/config.cmake.in
     "${CMAKE_CURRENT_BINARY_DIR}/emhashConfig.cmake"
     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/emhash
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ install(FILES
 )
 
 if(WITH_BENCHMARKS)
+    include_directories(${PROJECT_SOURCE_DIR})
     include_directories(${PROJECT_SOURCE_DIR}/thirdparty)
     include_directories(${PROJECT_SOURCE_DIR}/bench)
     add_definitions(-DHAVE_BOOST=1 -DABSL_HAMP=1 -DEMH_PSL=16)# -DET=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ set_target_properties(emhash PROPERTIES PUBLIC_HEADER "${EMHASH_HEADERS}")
 
 target_include_directories(
      emhash INTERFACE
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}}>
      $<INSTALL_INTERFACE:include>
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,9 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 install(TARGETS emhash
-        EXPORT emhash-targets)
+    EXPORT emhash-targets
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
 install(EXPORT emhash-targets
         FILE emhashTargets.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 
-project(emhash_bench)
+project(emhash)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -8,41 +8,85 @@ endif()
 
 set(CMAKE_CXX_STANDARD 17)
 
+option(WITH_BENCHMARKS "Build benchmarks." ON)
+
 message("------------ Options -------------")
 message("  CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 message("  CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
 message("  CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR} ")
 message("  CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
 
-include_directories(${PROJECT_SOURCE_DIR})
-include_directories(${PROJECT_SOURCE_DIR}/thirdparty)
-include_directories(${PROJECT_SOURCE_DIR}/bench)
+add_library(emhash INTERFACE)
 
-add_definitions(-DHAVE_BOOST=1 -DABSL_HAMP=1 -DEMH_PSL=16)# -DET=1)
-find_package(Threads REQUIRED)
+set(EMHASH_HEADERS
+    hash_set2.hpp
+    hash_set3.hpp
+    hash_set4.hpp
+    hash_set8.hpp
+    hash_table5.hpp
+    hash_table6.hpp
+    hash_table7.hpp
+    hash_table8.hpp
+)
 
-if(WIN32)
-    set(CMAKE_CXX_FLAGS "/WX- /MP")
-    set(CMAKE_CXX_FLAGS_DEBUG "/W3 /Zi /Od /WX- ${CMAKE_CXX_FLAGS}")
-    set(CMAKE_CXX_FLAGS_RELEASE "/Ob1 /Ot /Oi /Oy /GL /arch:AVX ${CMAKE_CXX_FLAGS}")
-    add_compile_options(/Ob2 /DNDEBUG /O2 /Ot /Oi /Oy /GL /arch:AVX)
-elseif(1)
-	set(CMAKE_CXX_FLAGS_DEBUG "-g fno-strict-aliasing ${CMAKE_CXX_FLAGS}")
-    set(CMAKE_CXX_FLAGS "-flto=auto -march=native  ${CMAKE_CXX_FLAGS}")
+set_target_properties(emhash PROPERTIES PUBLIC_HEADER "${EMHASH_HEADERS}")
+
+target_include_directories(
+     emhash INTERFACE
+     $<INSTALL_INTERFACE:include>
+)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+install(TARGETS emhash
+        EXPORT emhash-targets)
+
+install(EXPORT emhash-targets
+        FILE emhashTargets.cmake
+        NAMESPACE emhash::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/emhash
+)
+
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/emhashConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/emhash
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/emhashConfig.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/emhash
+)
+
+if(WITH_BENCHMARKS)
+    include_directories(${PROJECT_SOURCE_DIR}/thirdparty)
+    include_directories(${PROJECT_SOURCE_DIR}/bench)
+    add_definitions(-DHAVE_BOOST=1 -DABSL_HAMP=1 -DEMH_PSL=16)# -DET=1)
+    find_package(Threads REQUIRED)
+    if(WIN32)
+        set(CMAKE_CXX_FLAGS "/WX- /MP")
+        set(CMAKE_CXX_FLAGS_DEBUG "/W3 /Zi /Od /WX- ${CMAKE_CXX_FLAGS}")
+        set(CMAKE_CXX_FLAGS_RELEASE "/Ob1 /Ot /Oi /Oy /GL /arch:AVX ${CMAKE_CXX_FLAGS}")
+        add_compile_options(/Ob2 /DNDEBUG /O2 /Ot /Oi /Oy /GL /arch:AVX)
+    elseif(1)
+      set(CMAKE_CXX_FLAGS_DEBUG "-g fno-strict-aliasing ${CMAKE_CXX_FLAGS}")
+        set(CMAKE_CXX_FLAGS "-flto=auto -march=native  ${CMAKE_CXX_FLAGS}")
+    endif()
+
+    add_executable(ebench ${PROJECT_SOURCE_DIR}/bench/ebench.cpp)
+    add_executable(sbench ${PROJECT_SOURCE_DIR}/bench/sbench.cpp)
+    add_executable(mbench ${PROJECT_SOURCE_DIR}/bench/martin_bench.cpp)
+    add_executable(bs ${PROJECT_SOURCE_DIR}/bench/bstring.cpp)
+    add_executable(bi ${PROJECT_SOURCE_DIR}/bench/buint64.cpp)
+    add_executable(fbench ${PROJECT_SOURCE_DIR}/bench/fbench.cpp)
+    add_executable(hbench ${PROJECT_SOURCE_DIR}/bench/hbench.cpp)
+    #add_executable(qbench ${PROJECT_SOURCE_DIR}/bench/qbench.cpp)
+    #add_executable(sibench ${PROJECT_SOURCE_DIR}/bench/simple_bench.cpp)
+
+    #target_link_libraries(ebench PRIVATE Threads::Threads)
+    #target_link_libraries(sbench PRIVATE Threads::Threads)
+    #target_link_libraries(mbench PRIVATE Threads::Threads)
+    #target_link_libraries(hbench PRIVATE Threads::Threads)
+    #target_link_libraries(fbench PRIVATE Threads::Threads)
 endif()
 
-add_executable(ebench ${PROJECT_SOURCE_DIR}/bench/ebench.cpp)
-add_executable(sbench ${PROJECT_SOURCE_DIR}/bench/sbench.cpp)
-add_executable(mbench ${PROJECT_SOURCE_DIR}/bench/martin_bench.cpp)
-add_executable(bs ${PROJECT_SOURCE_DIR}/bench/bstring.cpp)
-add_executable(bi ${PROJECT_SOURCE_DIR}/bench/buint64.cpp)
-add_executable(fbench ${PROJECT_SOURCE_DIR}/bench/fbench.cpp)
-add_executable(hbench ${PROJECT_SOURCE_DIR}/bench/hbench.cpp)
-#add_executable(qbench ${PROJECT_SOURCE_DIR}/bench/qbench.cpp)
-#add_executable(sibench ${PROJECT_SOURCE_DIR}/bench/simple_bench.cpp)
-
-#target_link_libraries(ebench PRIVATE Threads::Threads)
-#target_link_libraries(sbench PRIVATE Threads::Threads)
-#target_link_libraries(mbench PRIVATE Threads::Threads)
-#target_link_libraries(hbench PRIVATE Threads::Threads)
-#target_link_libraries(fbench PRIVATE Threads::Threads)

--- a/config.cmake.in
+++ b/config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/emhashTargets.cmake")
+
+check_required_components(emhash)


### PR DESCRIPTION
DPCPP [1] these days depends on emhash, and for the blender build of it we supply this our selves rather than having dpcpp download it, for libs we supply our selves we generally build+install them, emhash didn't support this so this PR adds some of the required boiler plate code.

nothing too crazy pretty much follows the cmake guidance [2]

once in place down stream users of emhash can just use

```
find_package(emhash REQUIRED)
target_link_libraries(my_app PRIVATE emhash::emhash)
```

to consume emhash

also this adds an option to toggle the building of the benchmarks they are not required in our use-case, so having an option to disable them is nice (they had some build issues on vs2022)

[1] https://github.com/intel/llvm
[2] https://cmake.org/cmake/help/latest/guide/importing-exporting/index.html