### PR TITLE
feat: add AllocT template parameter to HashMap and HashSet

### DIFF
--- a/hash_set2.hpp
+++ b/hash_set2.hpp
@@ -48,6 +48,7 @@
 #include <cstdint>
 #include <functional>
 #include <iterator>
+#include <memory>
 
 #ifdef __has_include
     #if __has_include("wyhash.h")
@@ -82,7 +83,7 @@
 namespace emhash2 {
 
 /// A cache-friendly hash table with open addressing, linear probing and power-of-two capacity
-template <typename KeyT, typename HashT = std::hash<KeyT>, typename EqT = std::equal_to<KeyT>>
+template <typename KeyT, typename HashT = std::hash<KeyT>, typename EqT = std::equal_to<KeyT>, typename AllocT = std::allocator<KeyT>>
 class HashSet
 {
 public:
@@ -96,7 +97,8 @@ public:
 #endif
 
     static constexpr size_type INACTIVE = size_type(0 - 1ull);
-    typedef HashSet<KeyT, HashT, EqT> htype;
+    typedef HashSet<KeyT, HashT, EqT, AllocT> htype;
+    typedef AllocT allocator_type;
     typedef std::pair<KeyT, size_type> PairT;
     static constexpr bool bInCacheLine = sizeof(PairT) < 64 * 2 / 3;
     static constexpr float default_load_factor = 0.95f;
@@ -249,13 +251,46 @@ public:
         init(bucket, lf);
     }
 
+    explicit HashSet(const allocator_type& alloc)
+        : _alloc(alloc)
+    {
+        init(2, default_load_factor);
+    }
+
+    HashSet(size_type bucket, float lf, const allocator_type& alloc)
+        : _alloc(alloc)
+    {
+        init(bucket, lf);
+    }
+
     HashSet(const HashSet& other)
+        : _alloc(PairAllocTraits::select_on_container_copy_construction(other._alloc))
+    {
+        _pairs = alloc_bucket(other._num_buckets);
+        clone(other);
+    }
+
+    HashSet(const HashSet& other, const allocator_type& alloc)
+        : _alloc(alloc)
     {
         _pairs = alloc_bucket(other._num_buckets);
         clone(other);
     }
 
     HashSet(HashSet&& other)
+        : _alloc(std::move(other._alloc))
+    {
+#ifdef EMH_MOVE_EMPTY
+        _pairs = nullptr;
+        _num_buckets = _num_filled = 0;
+#else
+        init(4, default_load_factor);
+#endif
+        swap(other);
+    }
+
+    HashSet(HashSet&& other, const allocator_type& alloc)
+        : _alloc(alloc)
     {
 #ifdef EMH_MOVE_EMPTY
         _pairs = nullptr;
@@ -286,11 +321,14 @@ public:
         if (this == &other)
             return *this;
 
+        if constexpr (PairAllocTraits::propagate_on_container_copy_assignment::value)
+            _alloc = other._alloc;
+
         if (!std::is_trivially_destructible<KeyT>::value)
             clearkv();
 
         if (_num_buckets != other._num_buckets) {
-            free(_pairs);
+            dealloc_bucket(_pairs, _num_buckets);
             _pairs = alloc_bucket(other._num_buckets);
         }
 
@@ -312,7 +350,7 @@ public:
         if (!std::is_trivially_destructible<KeyT>::value)
             clearkv();
 
-        free(_pairs);
+        dealloc_bucket(_pairs, _num_buckets);
     }
 
     void clone(const HashSet& other)
@@ -341,6 +379,7 @@ public:
     {
         std::swap(_hasher, other._hasher);
 //      std::swap(_eq, other._eq);
+        std::swap(_alloc, other._alloc);
         std::swap(_pairs, other._pairs);
         std::swap(_num_buckets, other._num_buckets);
         std::swap(_num_filled, other._num_filled);
@@ -409,6 +448,11 @@ public:
     float load_factor() const
     {
         return static_cast<float>(_num_filled) / (_num_buckets + 0.01f);
+    }
+
+    allocator_type get_allocator() const
+    {
+        return allocator_type(_alloc);
     }
 
     const HashT& hash_function() const
@@ -950,10 +994,15 @@ public:
         return true;
     }
 
-    static inline PairT* alloc_bucket(size_type num_buckets)
+    inline PairT* alloc_bucket(size_type num_buckets)
     {
-        auto new_pairs = (char*)malloc((2 + num_buckets) * sizeof(PairT));
-        return (PairT*)(new_pairs);
+        return PairAllocTraits::allocate(_alloc, num_buckets + 2);
+    }
+
+    inline void dealloc_bucket(PairT* pairs, size_type num_buckets)
+    {
+        if (pairs)
+            PairAllocTraits::deallocate(_alloc, pairs, num_buckets + 2);
     }
 
 private:
@@ -990,7 +1039,7 @@ private:
         //assert(num_buckets > _num_filled);
         auto new_pairs = (PairT*)alloc_bucket(num_buckets);
         auto old_num_filled  = _num_filled;
-        //auto old_num_buckets = _num_buckets;
+        auto old_num_buckets = _num_buckets;
         auto old_pairs = _pairs;
 
         _num_filled  = 0;
@@ -1037,7 +1086,7 @@ private:
         }
 #endif
 
-        free(old_pairs);
+        dealloc_bucket(old_pairs, old_num_buckets);
         assert(old_num_filled == _num_filled);
     }
 
@@ -1367,10 +1416,14 @@ private:
 
 private:
 
+    using PairAlloc = typename std::allocator_traits<AllocT>::template rebind_alloc<PairT>;
+    using PairAllocTraits = std::allocator_traits<PairAlloc>;
+
     //the first cache line packed
     PairT*    _pairs;
     HashT     _hasher;
     EqT       _eq;
+    PairAlloc _alloc;
     uint32_t   _loadlf;
     size_type  _mask;
 

--- a/hash_set3.hpp
+++ b/hash_set3.hpp
@@ -47,6 +47,7 @@
 #include <cstdint>
 #include <functional>
 #include <iterator>
+#include <memory>
 
 #ifdef  EMH_KEY
     #undef  EMH_BUCKET
@@ -90,7 +91,7 @@
 
 namespace emhash7 {
 /// A cache-friendly hash table with open addressing, linear probing and power-of-two capacity
-template <typename KeyT, typename HashT = std::hash<KeyT>, typename EqT = std::equal_to<KeyT>>
+template <typename KeyT, typename HashT = std::hash<KeyT>, typename EqT = std::equal_to<KeyT>, typename AllocT = std::allocator<KeyT>>
 class HashSet
 {
 public:
@@ -109,11 +110,15 @@ public:
     typedef KeyT     value_type;
     typedef KeyT& reference;
     typedef const KeyT& const_reference;
+    typedef AllocT   allocator_type;
 
 
 private:
-    typedef HashSet<KeyT, HashT, EqT> htype;
+    typedef HashSet<KeyT, HashT, EqT, AllocT> htype;
     typedef std::pair<KeyT, size_type> PairT;
+
+    using PairAlloc = typename std::allocator_traits<AllocT>::template rebind_alloc<PairT>;
+    using PairAllocTraits = std::allocator_traits<PairAlloc>;
 
 public:
     class iterator
@@ -245,6 +250,17 @@ public:
 
     // ------------------------------------------------------------------------
 
+    PairT* alloc_bucket(size_type num_buckets)
+    {
+        return PairAllocTraits::allocate(_alloc, num_buckets);
+    }
+
+    void dealloc_bucket(PairT* ptr, size_type num_buckets)
+    {
+        if (ptr)
+            PairAllocTraits::deallocate(_alloc, ptr, num_buckets);
+    }
+
     void init()
     {
         _colls_buckets = 0;
@@ -259,15 +275,38 @@ public:
         max_load_factor(0.9f);
     }
 
-    HashSet(size_type bucket = 4)
+    allocator_type get_allocator() const
+    {
+        return allocator_type(_alloc);
+    }
+
+    HashSet(size_type bucket = 4, const HashT& hash = HashT(), const EqT& eq = EqT(), const AllocT& alloc = AllocT())
+        : _alloc(alloc)
     {
         init();
+        _hasher = hash;
+        _eq = eq;
         reserve(bucket);
     }
 
-    HashSet(const HashSet& other)
+    explicit HashSet(const AllocT& alloc)
+        : _alloc(alloc)
     {
-        _pairs = (PairT*)malloc((1 + other._total_buckets) * sizeof(PairT));
+        init();
+        reserve(4);
+    }
+
+    HashSet(const HashSet& other)
+        : _alloc(PairAllocTraits::select_on_container_copy_construction(other._alloc))
+    {
+        _pairs = alloc_bucket(2 + other._total_buckets);
+        clone(other);
+    }
+
+    HashSet(const HashSet& other, const AllocT& alloc)
+        : _alloc(alloc)
+    {
+        _pairs = alloc_bucket(2 + other._total_buckets);
         clone(other);
     }
 
@@ -298,15 +337,27 @@ public:
     }
 
     HashSet(HashSet&& other)
+        : _alloc(std::move(other._alloc))
     {
         init();
         reserve(1);
         *this = std::move(other);
     }
 
-    HashSet(std::initializer_list<key_type> il, size_type n = 8)
+    HashSet(HashSet&& other, const AllocT& alloc)
+        : _alloc(alloc)
     {
         init();
+        reserve(1);
+        *this = std::move(other);
+    }
+
+    HashSet(std::initializer_list<key_type> il, size_type n = 8, const HashT& hash = HashT(), const EqT& eq = EqT(), const AllocT& alloc = AllocT())
+        : _alloc(alloc)
+    {
+        init();
+        _hasher = hash;
+        _eq = eq;
         reserve((size_type)il.size());
         for (auto begin = il.begin(); begin != il.end(); ++begin)
             insert(*begin);
@@ -321,8 +372,13 @@ public:
             clearkv();
 
         if (_total_buckets != other._total_buckets) {
-            free(_pairs);
-            _pairs = (PairT*)malloc((1 + other._total_buckets) * sizeof(PairT));
+            dealloc_bucket(_pairs, 2 + _total_buckets);
+            if constexpr (PairAllocTraits::propagate_on_container_copy_assignment::value)
+                _alloc = other._alloc;
+            _pairs = alloc_bucket(2 + other._total_buckets);
+        } else {
+            if constexpr (PairAllocTraits::propagate_on_container_copy_assignment::value)
+                _alloc = other._alloc;
         }
 
         clone(other);
@@ -343,7 +399,7 @@ public:
         if (!std::is_trivially_destructible<KeyT>::value)
             clearkv();
 
-        free(_pairs);
+        dealloc_bucket(_pairs, _total_buckets > 0 ? 2 + _total_buckets : 0);
     }
 
     void swap(HashSet& other)
@@ -361,6 +417,7 @@ public:
         std::swap(_num_colls, other._num_colls);
         std::swap(_num_mains, other._num_mains);
         std::swap(_pairs, other._pairs);
+        std::swap(_alloc, other._alloc);
     }
 
     // -------------------------------------------------------------
@@ -891,7 +948,7 @@ public:
 
         const auto num_buckets = (size_type)buckets;
         const auto main_bucket = num_buckets;
-        auto new_pairs = (PairT*)malloc((2ull + num_buckets + main_bucket) * sizeof(PairT));
+        auto new_pairs = alloc_bucket((size_type)(2ull + num_buckets + main_bucket));
         auto old_pairs = _pairs;
 
 #if EMH_REHASH_LOG
@@ -979,7 +1036,7 @@ public:
             EMH_BUCKET(_pairs, new_bucket) = new_bucket;
         }
 
-        free(old_pairs);
+        dealloc_bucket(old_pairs, old_total_buckets > 0 ? 2 + old_total_buckets : 0);
 
 #if EMH_REHASH_LOG
         if (_num_colls > 100000) {
@@ -1329,6 +1386,7 @@ private:
     size_type  _num_colls;
     size_type  _num_mains;
     PairT*    _pairs;
+    PairAlloc _alloc;
 };
 } // namespace emhash
 #if __cplusplus > 199711

--- a/hash_set4.hpp
+++ b/hash_set4.hpp
@@ -35,6 +35,7 @@
 #include <cstdint>
 #include <functional>
 #include <iterator>
+#include <memory>
 
 #ifdef __has_include
     #if __has_include("wyhash.h")
@@ -105,7 +106,7 @@ static uint32_t CTZ(size_t n)
 }
 
 /// A cache-friendly hash table with open addressing, linear probing and power-of-two capacity
-template <typename KeyT, typename HashT = std::hash<KeyT>, typename EqT = std::equal_to<KeyT>>
+template <typename KeyT, typename HashT = std::hash<KeyT>, typename EqT = std::equal_to<KeyT>, typename AllocT = std::allocator<KeyT>>
 class HashSet
 {
 public:
@@ -117,8 +118,11 @@ public:
     typedef uint32_t size_type;
 #endif
 
-    typedef HashSet<KeyT, HashT, EqT> htype;
+    typedef HashSet<KeyT, HashT, EqT, AllocT> htype;
+    typedef AllocT allocator_type;
     typedef std::pair<KeyT, uint32_t> PairT;
+    using PairAlloc = typename std::allocator_traits<AllocT>::template rebind_alloc<PairT>;
+    using PairAllocTraits = std::allocator_traits<PairAlloc>;
     static constexpr bool bInCacheLine = sizeof(PairT) < 64 * 2 / 3;
     static constexpr uint32_t INACTIVE = (uint32_t)(0 - 1);
 
@@ -316,6 +320,29 @@ public:
 
     // ------------------------------------------------------------------------
 
+    static size_type alloc_count(size_type num_buckets)
+    {
+        const auto num_byte = num_buckets / 8;
+        const auto total_bytes = (2 + num_buckets) * sizeof(PairT) + num_byte + sizeof(size_t);
+        return (size_type)((total_bytes + sizeof(PairT) - 1) / sizeof(PairT));
+    }
+
+    PairT* alloc_bucket(size_type num_buckets)
+    {
+        return PairAllocTraits::allocate(_alloc, alloc_count(num_buckets));
+    }
+
+    void dealloc_bucket(PairT* pairs, size_type num_buckets)
+    {
+        if (pairs)
+            PairAllocTraits::deallocate(_alloc, pairs, alloc_count(num_buckets));
+    }
+
+    allocator_type get_allocator() const
+    {
+        return allocator_type(_alloc);
+    }
+
     void init(size_type bucket, float load_factor = 0.95f)
     {
         _num_buckets = 0;
@@ -332,13 +359,46 @@ public:
         init(bucket, load_factor);
     }
 
-    HashSet(const HashSet& other)
+    explicit HashSet(const allocator_type& alloc)
+        : _alloc(alloc)
     {
-        _pairs = (PairT*)malloc((2 + other._num_buckets) * sizeof(PairT) + other._num_buckets / 8 + sizeof(size_t));
+        init(4, 0.95f);
+    }
+
+    HashSet(size_type bucket, float load_factor, const allocator_type& alloc)
+        : _alloc(alloc)
+    {
+        init(bucket, load_factor);
+    }
+
+    HashSet(const HashSet& other)
+        : _alloc(PairAllocTraits::select_on_container_copy_construction(other._alloc))
+    {
+        _pairs = alloc_bucket(other._num_buckets);
+        clone(other);
+    }
+
+    HashSet(const HashSet& other, const allocator_type& alloc)
+        : _alloc(alloc)
+    {
+        _pairs = alloc_bucket(other._num_buckets);
         clone(other);
     }
 
     HashSet(HashSet&& other)
+        : _alloc(std::move(other._alloc))
+    {
+#ifdef EMH_MOVE_EMPTY
+        _pairs = nullptr;
+        _num_buckets = _num_filled = 0;
+#else
+        init(4, 0.95f);
+#endif
+        swap(other);
+    }
+
+    HashSet(HashSet&& other, const allocator_type& alloc)
+        : _alloc(alloc)
     {
 #ifdef EMH_MOVE_EMPTY
         _pairs = nullptr;
@@ -366,8 +426,13 @@ public:
             clearkv();
 
         if (_num_buckets != other._num_buckets) {
-            free(_pairs);
-            _pairs = (PairT*)malloc((2 + other._num_buckets) * sizeof(PairT) + other._num_buckets / 8 + sizeof(size_t));
+            dealloc_bucket(_pairs, _num_buckets);
+            if constexpr (PairAllocTraits::propagate_on_container_copy_assignment::value)
+                _alloc = other._alloc;
+            _pairs = alloc_bucket(other._num_buckets);
+        } else {
+            if constexpr (PairAllocTraits::propagate_on_container_copy_assignment::value)
+                _alloc = other._alloc;
         }
 
         clone(other);
@@ -388,7 +453,7 @@ public:
         if (isno_triviall_destructable())
             clearkv();
 
-        free(_pairs);
+        dealloc_bucket(_pairs, _num_buckets);
     }
 
     void clone(const HashSet& other)
@@ -423,6 +488,7 @@ public:
     {
         std::swap(_hasher, other._hasher);
 //      std::swap(_eq, other._eq);
+        std::swap(_alloc, other._alloc);
         std::swap(_pairs, other._pairs);
         std::swap(_num_buckets, other._num_buckets);
         std::swap(_num_filled, other._num_filled);
@@ -962,10 +1028,11 @@ private:
 #endif
 
         const auto num_byte = num_buckets / 8;
-        auto new_pairs = (PairT*)malloc((2 + num_buckets) * sizeof(PairT) + num_byte + sizeof(size_t));
+        auto new_pairs = alloc_bucket(num_buckets);
         //TODO: throwOverflowError
         auto old_num_filled  = _num_filled;
         auto old_pairs = _pairs;
+        auto old_num_buckets = _num_buckets;
 
         _num_filled  = 0;
         _num_buckets = num_buckets;
@@ -1010,7 +1077,7 @@ private:
         }
 #endif
 
-        free(old_pairs);
+        dealloc_bucket(old_pairs, old_num_buckets);
         assert(old_num_filled == _num_filled);
     }
 
@@ -1368,6 +1435,7 @@ private:
     uint8_t*  _bitmask;
     HashT     _hasher;
     EqT       _eq;
+    PairAlloc _alloc;
     uint32_t   _loadlf;
     size_type  _last;
     size_type  _num_buckets;
@@ -1377,6 +1445,6 @@ private:
 };
 } // namespace emhash
 #if __cplusplus >= 201103L
-template <class Key, typename Hash = std::hash<Key>> using em_hash_set = emhash9::HashSet<Key, Hash>;
+template <class Key, typename Hash = std::hash<Key>, typename Alloc = std::allocator<Key>> using em_hash_set = emhash9::HashSet<Key, Hash, std::equal_to<Key>, Alloc>;
 #endif
 

--- a/hash_set8.hpp
+++ b/hash_set8.hpp
@@ -78,8 +78,8 @@ struct DefaultPolicy8 {
 template<typename KeyT,
         typename HashT = std::hash<KeyT>,
         typename EqT = std::equal_to<KeyT>,
-        typename Allocator = std::allocator<KeyT>, //never used
-        typename Policy = DefaultPolicy8> //never used
+        typename AllocT = std::allocator<KeyT>,
+        typename Policy = DefaultPolicy8>
 class HashSet
 {
 #ifndef EMH_DEFAULT_LOAD_FACTOR
@@ -91,7 +91,7 @@ class HashSet
 #endif
 
 public:
-    using htype = HashSet<KeyT, HashT, EqT, Allocator, Policy>; //TODO:Allocator is not implemented
+    using htype = HashSet<KeyT, HashT, EqT, AllocT, Policy>;
     using value_type = KeyT; //TODO set to const KeyT
     using key_type = const KeyT;
     //using dPolicy = Policy;
@@ -106,6 +106,7 @@ public:
 
     using hasher = HashT;
     using key_equal = EqT;
+    using allocator_type = AllocT;
 
     constexpr static size_type INACTIVE = size_type(-1);
     constexpr static size_type EAD      = 2;
@@ -242,6 +243,7 @@ public:
         _index = nullptr;
         _mask  = _num_buckets = 0;
         _num_filled = 0;
+        _pairs_capacity = 0;
         _mlf = (uint32_t)((1 << 27) / EMH_DEFAULT_LOAD_FACTOR);
         max_load_factor(mlf);
         rehash(bucket);
@@ -253,9 +255,12 @@ public:
     }
 
     HashSet(const HashSet& rhs)
+        : _pair_allocator(PairAllocTraits::select_on_container_copy_construction(rhs._pair_allocator))
+        , _index_allocator(IndexAllocTraits::select_on_container_copy_construction(rhs._index_allocator))
     {
         if (rhs.load_factor() > EMH_MIN_LOAD_FACTOR) {
-            _pairs = alloc_bucket((size_type)((float)rhs._num_buckets * rhs.max_load_factor()) + 4);
+            _pairs_capacity = (size_type)((float)rhs._num_buckets * rhs.max_load_factor()) + 4;
+            _pairs = alloc_bucket(_pairs_capacity);
             _index = alloc_index(rhs._num_buckets);
             clone(rhs);
         } else {
@@ -266,6 +271,8 @@ public:
     }
 
     HashSet(HashSet&& rhs) noexcept
+        : _pair_allocator(std::move(rhs._pair_allocator))
+        , _index_allocator(std::move(rhs._index_allocator))
     {
         init(0);
         *this = std::move(rhs);
@@ -286,13 +293,56 @@ public:
             emplace(*begin);
     }
 
+    explicit HashSet(const allocator_type& alloc)
+        : _pair_allocator(alloc)
+        , _index_allocator(alloc)
+    {
+        init(2);
+    }
+
+    HashSet(size_type bucket, float mlf, const allocator_type& alloc)
+        : _pair_allocator(alloc)
+        , _index_allocator(alloc)
+    {
+        init(bucket, mlf);
+    }
+
+    HashSet(const HashSet& rhs, const allocator_type& alloc)
+        : _pair_allocator(alloc)
+        , _index_allocator(alloc)
+    {
+        if (rhs.load_factor() > EMH_MIN_LOAD_FACTOR) {
+            _pairs_capacity = (size_type)((float)rhs._num_buckets * rhs.max_load_factor()) + 4;
+            _pairs = alloc_bucket(_pairs_capacity);
+            _index = alloc_index(rhs._num_buckets);
+            clone(rhs);
+        } else {
+            init(rhs._num_filled + 2, rhs.max_load_factor());
+            for (auto it = rhs.begin(); it != rhs.end(); ++it)
+                insert_unique(*it);
+        }
+    }
+
+    HashSet(HashSet&& rhs, const allocator_type& alloc) noexcept
+        : _pair_allocator(alloc)
+        , _index_allocator(alloc)
+    {
+        init(0);
+        *this = std::move(rhs);
+    }
+
     HashSet& operator=(const HashSet& rhs)
     {
         if (this == &rhs)
             return *this;
 
+        if constexpr (PairAllocTraits::propagate_on_container_copy_assignment::value) {
+            _pair_allocator = rhs._pair_allocator;
+            _index_allocator = rhs._index_allocator;
+        }
+
         if (rhs.load_factor() < EMH_MIN_LOAD_FACTOR) {
-            clear(); free(_pairs); _pairs = nullptr;
+            clear(); dealloc_bucket(_pairs, _pairs_capacity); _pairs = nullptr; _pairs_capacity = 0;
             rehash(rhs._num_filled + 2);
             for (auto it = rhs.begin(); it != rhs.end(); ++it)
                 insert_unique(*it);
@@ -302,9 +352,10 @@ public:
         clearkv();
 
         if (_num_buckets != rhs._num_buckets) {
-            free(_pairs); free(_index);
+            dealloc_bucket(_pairs, _pairs_capacity); dealloc_index(_index, _num_buckets);
             _index = alloc_index(rhs._num_buckets);
-            _pairs = alloc_bucket((size_type)((float)rhs._num_buckets * rhs.max_load_factor()) + 4);
+            _pairs_capacity = (size_type)((float)rhs._num_buckets * rhs.max_load_factor()) + 4;
+            _pairs = alloc_bucket(_pairs_capacity);
         }
 
         clone(rhs);
@@ -340,8 +391,8 @@ public:
     ~HashSet() noexcept
     {
         clearkv();
-        free(_pairs);
-        free(_index);
+        dealloc_bucket(_pairs, _pairs_capacity);
+        dealloc_index(_index, _num_buckets);
         _num_filled = 0;
         _index = nullptr;
         _pairs = nullptr;
@@ -353,6 +404,7 @@ public:
 //        _eq          = rhs._eq;
         _num_buckets = rhs._num_buckets;
         _num_filled  = rhs._num_filled;
+        _pairs_capacity = rhs._pairs_capacity;
         _mlf         = rhs._mlf;
         _last        = rhs._last;
         _mask        = rhs._mask;
@@ -380,6 +432,7 @@ public:
         std::swap(_index, rhs._index);
         std::swap(_num_buckets, rhs._num_buckets);
         std::swap(_num_filled, rhs._num_filled);
+        std::swap(_pairs_capacity, rhs._pairs_capacity);
         std::swap(_mask, rhs._mask);
         std::swap(_mlf, rhs._mlf);
         std::swap(_last, rhs._last);
@@ -387,6 +440,8 @@ public:
         std::swap(_ehead, rhs._ehead);
 #endif
         std::swap(_etail, rhs._etail);
+        std::swap(_pair_allocator, rhs._pair_allocator);
+        std::swap(_index_allocator, rhs._index_allocator);
     }
 
     // -------------------------------------------------------------
@@ -420,6 +475,7 @@ public:
 
     const HashT& hash_function() const { return _hasher; }
     const EqT& key_eq() const { return _eq; }
+    allocator_type get_allocator() const { return allocator_type(_pair_allocator); }
 
     void max_load_factor(float mlf)
     {
@@ -939,20 +995,26 @@ public:
         return true;
     }
 
-    static value_type* alloc_bucket(size_type num_buckets)
+    value_type* alloc_bucket(size_type num_buckets)
     {
-#ifdef EMH_ALLOC
-        auto new_pairs = aligned_alloc(32, (uint64_t)num_buckets * sizeof(value_type));
-#else
-        auto new_pairs = malloc((uint64_t)num_buckets * sizeof(value_type));
-#endif
-        return (value_type *)(new_pairs);
+        return PairAllocTraits::allocate(_pair_allocator, num_buckets);
     }
 
-    static Index* alloc_index(size_type num_buckets)
+    void dealloc_bucket(value_type* ptr, size_type num_buckets)
     {
-        auto new_index = malloc((EAD + (uint64_t)num_buckets) * sizeof(Index));
-        return (Index *)(new_index);
+        if (ptr)
+            PairAllocTraits::deallocate(_pair_allocator, ptr, num_buckets);
+    }
+
+    Index* alloc_index(size_type num_buckets)
+    {
+        return IndexAllocTraits::allocate(_index_allocator, num_buckets + EAD);
+    }
+
+    void dealloc_index(Index* ptr, size_type num_buckets)
+    {
+        if (ptr)
+            IndexAllocTraits::deallocate(_index_allocator, ptr, num_buckets + EAD);
     }
 
     bool reserve(size_type required_buckets) noexcept
@@ -989,11 +1051,11 @@ public:
         return true;
     }
 
-    void rebuild(size_type num_buckets, size_type required_buckets) noexcept
+    void rebuild(size_type num_buckets, size_type required_buckets, size_type old_num_buckets) noexcept
     {
-        free(_index);
+        dealloc_index(_index, old_num_buckets);
         const auto need_size = std::max((size_type)((double)num_buckets * max_load_factor()) + 4, required_buckets + 2);
-        auto new_pairs = (value_type*)alloc_bucket(need_size);
+        auto new_pairs = alloc_bucket(need_size);
         if (is_trivially_copyable()) {
             if (_pairs)
             memcpy((char*)new_pairs, (char*)_pairs, _num_filled * sizeof(value_type));
@@ -1004,9 +1066,10 @@ public:
                     _pairs[slot].~value_type();
             }
         }
-        free(_pairs);
+        dealloc_bucket(_pairs, _pairs_capacity);
         _pairs = new_pairs;
-        _index = (Index*)alloc_index (num_buckets);
+        _pairs_capacity = need_size;
+        _index = alloc_index(num_buckets);
 
         memset((char*)_index, (int)INACTIVE, sizeof(_index[0]) * num_buckets);
         memset((char*)(_index + num_buckets), 0, sizeof(_index[0]) * EAD);
@@ -1044,9 +1107,10 @@ public:
         _last = _mask;
         num_buckets += num_buckets * EMH_PACK_TAIL / 100; //add more 5-10%
 #endif
+        auto old_num_buckets = _num_buckets;
         _num_buckets = num_buckets;
 
-        rebuild(num_buckets, (size_type)required_buckets);
+        rebuild(num_buckets, (size_type)required_buckets, old_num_buckets);
 
 #ifdef EMH_SORT
         std::sort(_pairs, _pairs + _num_filled, [this](const value_type & l, const value_type & r) {
@@ -1672,6 +1736,11 @@ private:
         }
 
 private:
+    using PairAlloc = typename std::allocator_traits<AllocT>::template rebind_alloc<value_type>;
+    using PairAllocTraits = std::allocator_traits<PairAlloc>;
+    using IndexAlloc = typename std::allocator_traits<AllocT>::template rebind_alloc<Index>;
+    using IndexAllocTraits = std::allocator_traits<IndexAlloc>;
+
     Index*    _index;
     value_type*_pairs;
 
@@ -1686,5 +1755,8 @@ private:
     size_type _ehead;
 #endif
     size_type _etail;
+    size_type _pairs_capacity;
+    PairAlloc _pair_allocator;
+    IndexAlloc _index_allocator;
 };
 } // namespace emhash

--- a/hash_table5.hpp
+++ b/hash_table5.hpp
@@ -37,6 +37,7 @@
 #include <functional>
 #include <iterator>
 #include <algorithm>
+#include <memory>
 
 #if EMH_WY_HASH
     #include "wyhash.h"
@@ -216,7 +217,7 @@ struct entry {
 };
 
 /// A cache-friendly hash table with open addressing, linear/qua probing and power-of-two capacity
-template <typename KeyT, typename ValueT, typename HashT = std::hash<KeyT>, typename EqT = std::equal_to<KeyT>>
+template <typename KeyT, typename ValueT, typename HashT = std::hash<KeyT>, typename EqT = std::equal_to<KeyT>, typename AllocT = std::allocator<std::pair<KeyT, ValueT>>>
 class HashMap
 {
 #ifndef EMH_DEFAULT_LOAD_FACTOR
@@ -225,7 +226,7 @@ class HashMap
     constexpr static float EMH_MIN_LOAD_FACTOR     = 0.25f; //< 0.5
 
 public:
-    typedef HashMap<KeyT, ValueT, HashT, EqT> htype;
+    typedef HashMap<KeyT, ValueT, HashT, EqT, AllocT> htype;
     typedef std::pair<KeyT, ValueT>           value_type;
 
 #if EMH_BUCKET_INDEX == 0
@@ -244,6 +245,7 @@ public:
     typedef ValueT mapped_type;
     typedef HashT  hasher;
     typedef EqT    key_equal;
+    typedef AllocT allocator_type;
     typedef PairT&       reference;
     typedef const PairT& const_reference;
 
@@ -361,6 +363,7 @@ public:
     }
 
     HashMap(const HashMap& rhs) noexcept
+        : _alloc(PairAllocTraits::select_on_container_copy_construction(rhs._alloc))
     {
         if (rhs.load_factor() > EMH_MIN_LOAD_FACTOR) {
             _pairs = alloc_bucket(rhs._num_buckets);
@@ -373,6 +376,7 @@ public:
     }
 
     HashMap(HashMap&& rhs) noexcept
+        : _alloc(std::move(rhs._alloc))
     {
         init(0);
         *this = std::move(rhs);
@@ -393,17 +397,31 @@ public:
             emplace(*first);
     }
 
+    explicit HashMap(const AllocT& alloc) noexcept
+        : _alloc(PairAlloc(alloc))
+    {
+        init(2, EMH_DEFAULT_LOAD_FACTOR);
+    }
+
+    HashMap(size_type bucket, float mlf, const AllocT& alloc) noexcept
+        : _alloc(PairAlloc(alloc))
+    {
+        init(bucket, mlf);
+    }
+
     HashMap& operator=(const HashMap& rhs) noexcept
     {
         if (this == &rhs)
             return *this;
+        if constexpr (PairAllocTraits::propagate_on_container_copy_assignment::value)
+            _alloc = rhs._alloc;
 
         if (rhs.load_factor() < EMH_MIN_LOAD_FACTOR) {
             clear();
 #if EMH_SMALL_SIZE
             if (_pairs != (PairT*)_small)
 #endif
-            free(_pairs);
+            dealloc_bucket(_pairs, _num_buckets);
             _pairs = nullptr;
 
             rehash((uint64_t)rhs._num_filled + 2);
@@ -417,7 +435,7 @@ public:
 #if EMH_SMALL_SIZE
             if (_pairs != (PairT*)_small)
 #endif
-            free(_pairs);
+            dealloc_bucket(_pairs, _num_buckets);
             _pairs = alloc_bucket(rhs._num_buckets);
         }
 
@@ -437,7 +455,7 @@ public:
                 return *this;
             if (rhs._num_buckets > _num_buckets) {
                 if (_pairs != (PairT*)_small) {
-                    free(_pairs); _pairs = (PairT*)_small;
+                    dealloc_bucket(_pairs, _num_buckets); _pairs = (PairT*)_small;
                 }
                 if (rhs._num_buckets > EMH_SMALL_SIZE)
                 _pairs = alloc_bucket(rhs._num_buckets);
@@ -475,7 +493,7 @@ public:
 #if EMH_SMALL_SIZE
         if (_pairs != (PairT*)_small)
 #endif
-        free(_pairs);
+        dealloc_bucket(_pairs, _num_buckets);
         _pairs = nullptr;
     }
 
@@ -529,6 +547,7 @@ public:
         }
 #endif
         //      std::swap(_eq, rhs._eq);
+        std::swap(_alloc, rhs._alloc);
         std::swap(_hasher, rhs._hasher);
         std::swap(_pairs, rhs._pairs);
         std::swap(_num_buckets, rhs._num_buckets);
@@ -591,6 +610,7 @@ public:
 
     HashT hash_function() const noexcept { return static_cast<const HashT&>(_hasher); }
     EqT key_eq() const noexcept { return static_cast<const EqT&>(_eq); }
+    allocator_type get_allocator() const noexcept { return allocator_type(_alloc); }
 
     float load_factor() const noexcept { return static_cast<float>(_num_filled) / (float)_num_buckets; }
     float max_load_factor() const noexcept { return (1 << 27) / (float)_mlf; }
@@ -1483,21 +1503,20 @@ public:
 #if EMH_SMALL_SIZE
         if (old_pairs != (PairT*)_small)
 #endif
-        free(old_pairs);
+        dealloc_bucket(old_pairs, old_buckets);
         assert(old_num_filled == _num_filled);
     }
 
 private:
 
-    static PairT* alloc_bucket(size_type num_buckets)
+    PairT* alloc_bucket(size_type num_buckets)
     {
-        //TODO: call realloc
-#ifdef EMH_ALLOC
-        auto* new_pairs = (PairT*)aligned_alloc(EMH_MALIGN, (2 + num_buckets) * sizeof(PairT));
-#else
-        auto* new_pairs = (PairT*)malloc((2 + (size_t)num_buckets) * sizeof(PairT));
-#endif
-        return new_pairs;
+        return PairAllocTraits::allocate(_alloc, 2 + (size_t)num_buckets);
+    }
+
+    void dealloc_bucket(PairT* pairs, size_type num_buckets)
+    {
+        if (pairs) PairAllocTraits::deallocate(_alloc, pairs, 2 + (size_t)num_buckets);
     }
 
 #if EMH_HIGH_LOAD
@@ -2034,6 +2053,9 @@ one-way search strategy.
         return (size_type)_hasher(key);
     }
 
+    using PairAlloc = typename std::allocator_traits<AllocT>::template rebind_alloc<PairT>;
+    using PairAllocTraits = std::allocator_traits<PairAlloc>;
+
 private:
     PairT*    _pairs;
 #if EMH_SMALL_SIZE
@@ -2042,6 +2064,7 @@ private:
 
     HashT     _hasher;
     EqT       _eq;
+    PairAlloc _alloc;
     uint32_t  _mlf;
     size_type _mask;
     size_type _num_buckets;

--- a/hash_table6.hpp
+++ b/hash_table6.hpp
@@ -37,6 +37,7 @@
 #include <functional>
 #include <iterator>
 #include <algorithm>
+#include <memory>
 
 #if EMH_WY_HASH
     #include "wyhash.h"
@@ -222,7 +223,7 @@ struct entry {
 };
 
 /// A cache-friendly hash table with open addressing, linear/qua probing and power-of-two capacity
-template <typename KeyT, typename ValueT, typename HashT = std::hash<KeyT>, typename EqT = std::equal_to<KeyT>>
+template <typename KeyT, typename ValueT, typename HashT = std::hash<KeyT>, typename EqT = std::equal_to<KeyT>, typename AllocT = std::allocator<std::pair<KeyT, ValueT>>>
 class HashMap
 {
 #ifndef EMH_DEFAULT_LOAD_FACTOR
@@ -231,8 +232,9 @@ class HashMap
     constexpr static float EMH_MIN_LOAD_FACTOR     = 0.25f;
 
 public:
-    typedef HashMap<KeyT, ValueT, HashT, EqT> htype;
+    typedef HashMap<KeyT, ValueT, HashT, EqT, AllocT> htype;
     typedef std::pair<KeyT, ValueT>           value_type;
+    typedef AllocT                            allocator_type;
 
 #if EMH_BUCKET_INDEX == 0
     typedef value_type                        value_pair;
@@ -469,15 +471,25 @@ public:
         init(bucket, lf);
     }
 
+    explicit HashMap(const AllocT& alloc) : _alloc(PairAlloc(alloc))
+    {
+        init(2, EMH_DEFAULT_LOAD_FACTOR);
+    }
+
+    HashMap(size_type bucket, float mlf, const AllocT& alloc) : _alloc(PairAlloc(alloc))
+    {
+        init(bucket, mlf);
+    }
+
     size_t AllocSize(uint64_t num_buckets) const
     {
         return (num_buckets + PACK_SIZE) * sizeof(PairT) + (num_buckets + 7) / 8 + BIT_PACK;
     }
 
-    HashMap(const HashMap& rhs)
+    HashMap(const HashMap& rhs) : _alloc(PairAllocTraits::select_on_container_copy_construction(rhs._alloc))
     {
         if (rhs.load_factor() > EMH_MIN_LOAD_FACTOR) {
-            _pairs = (PairT*)malloc(AllocSize(rhs._mask + 1));
+            _pairs = alloc_bucket(rhs._mask + 1);
             clone(rhs);
         } else {
             init(rhs._num_filled + 2, rhs.max_load_factor());
@@ -486,7 +498,7 @@ public:
         }
     }
 
-    HashMap(HashMap&& rhs) noexcept
+    HashMap(HashMap&& rhs) noexcept : _alloc(std::move(rhs._alloc))
     {
 #ifndef EMH_ZERO_MOVE
         init(4);
@@ -517,8 +529,11 @@ public:
         if (this == &rhs)
             return *this;
 
+        if constexpr (PairAllocTraits::propagate_on_container_copy_assignment::value)
+            _alloc = rhs._alloc;
+
         if (rhs.load_factor() < EMH_MIN_LOAD_FACTOR) {
-            clear(); free(_pairs); _pairs = nullptr;
+            clear(); dealloc_bucket(_pairs, _mask + 1); _pairs = nullptr;
             rehash(rhs._num_filled + 2);
             for (auto it = rhs.begin(); it != rhs.end(); ++it)
                 insert_unique(it->first, it->second);
@@ -529,8 +544,8 @@ public:
             clearkv();
 
         if (_mask != rhs._mask) {
-            free(_pairs);
-            _pairs = (PairT*)malloc(AllocSize(1 + rhs._mask));
+            dealloc_bucket(_pairs, _mask + 1);
+            _pairs = alloc_bucket(1 + rhs._mask);
         }
 
         clone(rhs);
@@ -571,7 +586,7 @@ public:
                 it->~value_pair();
             }
         }
-        free(_pairs);
+        dealloc_bucket(_pairs, _mask + 1);
         _pairs = nullptr;
     }
 
@@ -606,6 +621,7 @@ public:
     {
         std::swap(_hasher, rhs._hasher);
 //      std::swap(_eq, rhs._eq);
+        std::swap(_alloc, rhs._alloc);
         std::swap(_pairs, rhs._pairs);
 #if EMH_SAFE_HASH
         std::swap(_num_main, rhs._num_main);
@@ -675,6 +691,7 @@ public:
 
     const HashT& hash_function() const { return _hasher; }
     const EqT& key_eq() const { return _eq; }
+    allocator_type get_allocator() const noexcept { return allocator_type(_alloc); }
 
     void max_load_factor(float mlf)
     {
@@ -1261,13 +1278,7 @@ public:
         //assert(num_buckets > _num_filled);
         auto old_num_filled  = _num_filled;
         auto old_mask        = _mask;
-        auto* new_pairs = (PairT*)malloc(AllocSize(num_buckets));
-#if EMH_EXCEPTION
-        if (EMH_UNLIKELY(!new_pairs))
-            throw std::bad_alloc();
-#else
-        assert(!!new_pairs);
-#endif
+        auto* new_pairs = alloc_bucket(num_buckets);
 
         auto old_pairs = _pairs;
 
@@ -1345,7 +1356,7 @@ public:
         }
 #endif
 
-        free(old_pairs);
+        dealloc_bucket(old_pairs, old_mask + 1);
         assert(old_num_filled == _num_filled);
     }
 
@@ -1808,10 +1819,34 @@ private:
 
     //8 * 2 + 4 * 5 = 16 + 20 = 32
 private:
+    using PairAlloc = typename std::allocator_traits<AllocT>::template rebind_alloc<PairT>;
+    using PairAllocTraits = std::allocator_traits<PairAlloc>;
+
+    static size_type AllocPairCount(uint64_t num_buckets)
+    {
+        auto bytes = (num_buckets + PACK_SIZE) * sizeof(PairT) + (num_buckets + 7) / 8 + BIT_PACK;
+        return (size_type)((bytes + sizeof(PairT) - 1) / sizeof(PairT));
+    }
+
+    PairT* alloc_bucket(uint64_t num_buckets)
+    {
+        auto count = AllocPairCount(num_buckets);
+        return PairAllocTraits::allocate(_alloc, count);
+    }
+
+    void dealloc_bucket(PairT* ptr, uint64_t num_buckets)
+    {
+        if (ptr) {
+            auto count = AllocPairCount(num_buckets);
+            PairAllocTraits::deallocate(_alloc, ptr, count);
+        }
+    }
+
     uint8_t*  _bitmask;
     PairT*    _pairs;
     HashT     _hasher;
     EqT       _eq;
+    PairAlloc _alloc;
     size_type _mask;
     size_type _num_filled;
     uint32_t _mlf;

--- a/hash_table7.hpp
+++ b/hash_table7.hpp
@@ -87,6 +87,7 @@ of resizing granularity. Ignoring variance, the expected occurrences of list siz
 #include <functional>
 #include <iterator>
 #include <algorithm>
+#include <memory>
 
 #if EMH_WY_HASH
     #include "wyhash.h"
@@ -312,7 +313,7 @@ struct entry {
 };
 
 /// A cache-friendly hash table with open addressing, linear/qua probing and power-of-two capacity
-template <typename KeyT, typename ValueT, typename HashT = std::hash<KeyT>, typename EqT = std::equal_to<KeyT>>
+template <typename KeyT, typename ValueT, typename HashT = std::hash<KeyT>, typename EqT = std::equal_to<KeyT>, typename AllocT = std::allocator<std::pair<KeyT, ValueT>>>
 class HashMap
 {
 #ifndef EMH_DEFAULT_LOAD_FACTOR
@@ -321,8 +322,9 @@ class HashMap
     constexpr static float EMH_MIN_LOAD_FACTOR     = 0.25f;
 
 public:
-    typedef HashMap<KeyT, ValueT, HashT, EqT> htype;
+    typedef HashMap<KeyT, ValueT, HashT, EqT, AllocT> htype;
     typedef std::pair<KeyT, ValueT>           value_type;
+    typedef AllocT                            allocator_type;
 
 #if EMH_BUCKET_INDEX == 0
     typedef value_type                        value_pair;
@@ -342,6 +344,9 @@ public:
     typedef EqT    key_equal;
     typedef PairT&       reference;
     typedef const PairT& const_reference;
+
+    using PairAlloc = typename std::allocator_traits<AllocT>::template rebind_alloc<PairT>;
+    using PairAllocTraits = std::allocator_traits<PairAlloc>;
 
     class const_iterator;
     class iterator
@@ -555,25 +560,46 @@ public:
         init(bucket, mlf);
     }
 
+    explicit HashMap(const AllocT& alloc) noexcept : _alloc(PairAlloc(alloc))
+    {
+        init(2, EMH_DEFAULT_LOAD_FACTOR);
+    }
+
+    HashMap(size_type bucket, float mlf, const AllocT& alloc) noexcept : _alloc(PairAlloc(alloc))
+    {
+        init(bucket, mlf);
+    }
+
     static size_t AllocSize(uint64_t num_buckets)
     {
         return (num_buckets + EPACK_SIZE) * sizeof(PairT) + (num_buckets + 7) / 8 + BIT_PACK;
     }
 
-    static PairT* alloc_bucket(size_type num_buckets)
+    static size_type alloc_count(size_type num_buckets)
     {
-#ifdef EMH_ALLOC
-        auto* new_pairs = (PairT*)aligned_alloc(EMH_MALIGN, AllocSize(num_buckets));
-#else
-        auto* new_pairs = (PairT*)malloc(AllocSize(num_buckets));
-#endif
+        return (size_type)((AllocSize(num_buckets) + sizeof(PairT) - 1) / sizeof(PairT));
+    }
+
+    PairT* alloc_bucket(size_type num_buckets)
+    {
+        auto count = alloc_count(num_buckets);
+        auto* new_pairs = PairAllocTraits::allocate(_alloc, count);
         return new_pairs;
     }
 
+    void dealloc_bucket(PairT* pairs, size_type num_buckets)
+    {
+        if (pairs) {
+            auto count = alloc_count(num_buckets);
+            PairAllocTraits::deallocate(_alloc, pairs, count);
+        }
+    }
+
     HashMap(const HashMap& rhs) noexcept
+        : _alloc(PairAllocTraits::select_on_container_copy_construction(rhs._alloc))
     {
         if (rhs.load_factor() > EMH_MIN_LOAD_FACTOR) {
-            _pairs = (PairT*)alloc_bucket(rhs._num_buckets);
+            _pairs = alloc_bucket(rhs._num_buckets);
             clone(rhs);
         } else {
             init(rhs._num_filled + 2, rhs.max_load_factor());
@@ -583,6 +609,7 @@ public:
     }
 
     HashMap(HashMap&& rhs) noexcept
+        : _alloc(std::move(rhs._alloc))
     {
 #ifndef EMH_ZERO_MOVE
         init(4);
@@ -613,8 +640,11 @@ public:
         if (this == &rhs)
             return *this;
 
+        if constexpr (PairAllocTraits::propagate_on_container_copy_assignment::value)
+            _alloc = rhs._alloc;
+
         if (rhs.load_factor() < EMH_MIN_LOAD_FACTOR) {
-            clear(); free(_pairs); _pairs = nullptr;
+            clear(); dealloc_bucket(_pairs, _num_buckets); _pairs = nullptr;
             rehash(rhs._num_filled + 2);
             for (auto it = rhs.begin(); it != rhs.end(); ++it)
                 insert_unique(it->first, it->second);
@@ -625,7 +655,7 @@ public:
             clearkv();
 
         if (_num_buckets != rhs._num_buckets) {
-            free(_pairs);
+            dealloc_bucket(_pairs, _num_buckets);
             _pairs = alloc_bucket(rhs._num_buckets);
         }
 
@@ -667,7 +697,7 @@ public:
                 it->~value_pair();
             }
         }
-        free(_pairs);
+        dealloc_bucket(_pairs, _num_buckets);
         _pairs = nullptr;
     }
 
@@ -699,6 +729,7 @@ public:
     {
         std::swap(_hasher, rhs._hasher);
         //std::swap(_eq, rhs._eq);
+        std::swap(_alloc, rhs._alloc);
         std::swap(_pairs, rhs._pairs);
         std::swap(_num_buckets, rhs._num_buckets);
         std::swap(_num_filled, rhs._num_filled);
@@ -764,6 +795,7 @@ public:
 
     inline const HashT& hash_function() const { return _hasher; }
     inline const EqT& key_eq() const { return _eq; }
+    allocator_type get_allocator() const noexcept { return allocator_type(_alloc); }
 
     inline void max_load_factor(float mlf)
     {
@@ -1391,6 +1423,7 @@ public:
 
         auto num_buckets = (size_type)buckets;
         auto old_num_filled = _num_filled;
+        auto old_num_buckets = _num_buckets;
         auto old_mask  = _num_buckets - 1;
         auto old_pairs = _pairs;
         auto* obmask   = _bitmask;
@@ -1438,7 +1471,7 @@ public:
         }
 #endif
 
-        free(old_pairs);
+        dealloc_bucket(old_pairs, old_num_buckets);
         assert(old_num_filled == _num_filled);
     }
 
@@ -1892,6 +1925,7 @@ private:
     PairT*    _pairs;
     HashT     _hasher;
     EqT       _eq;
+    PairAlloc _alloc;
     size_type _mask;
     size_type _num_buckets;
 

--- a/hash_table8.hpp
+++ b/hash_table8.hpp
@@ -78,8 +78,8 @@ struct DefaultPolicy {
 template<typename KeyT, typename ValueT,
         typename HashT = std::hash<KeyT>,
         typename EqT = std::equal_to<KeyT>,
-        typename Allocator = std::allocator<std::pair<KeyT, ValueT>>, //never used
-        typename Policy = DefaultPolicy> //never used
+        typename AllocT = std::allocator<std::pair<KeyT, ValueT>>,
+        typename Policy = DefaultPolicy>
 class HashMap
 {
 #ifndef EMH_DEFAULT_LOAD_FACTOR
@@ -91,7 +91,7 @@ class HashMap
 #endif
 
 public:
-    using htype = HashMap<KeyT, ValueT, HashT, EqT, Allocator, Policy>; //TODO:Allocator is not implemented
+    using htype = HashMap<KeyT, ValueT, HashT, EqT, AllocT, Policy>;
     using value_type = std::pair<KeyT, ValueT>; //TODO set to const KeyT
 //    using value_type = std::pair<const KeyT, ValueT>; //TODO set to const KeyT
     using key_type = const KeyT;
@@ -108,6 +108,7 @@ public:
 
     using hasher = HashT;
     using key_equal = EqT;
+    using allocator_type = AllocT;
 
     constexpr static size_type INACTIVE = size_type(-1);
     constexpr static size_type EAD      = 2;
@@ -202,6 +203,7 @@ public:
         _index = nullptr;
         _mask  = _num_buckets = 0;
         _num_filled = 0;
+        _pairs_capacity = 0;
         _mlf = (uint32_t)((1 << 28) / EMH_DEFAULT_LOAD_FACTOR);
         max_load_factor(mlf);
         rehash(bucket);
@@ -213,9 +215,12 @@ public:
     }
 
     HashMap(const HashMap& rhs)
+        : _pair_allocator(PairAllocTraits::select_on_container_copy_construction(rhs._pair_allocator))
+        , _index_allocator(IndexAllocTraits::select_on_container_copy_construction(rhs._index_allocator))
     {
         if (rhs.load_factor() > EMH_MIN_LOAD_FACTOR) {
-            _pairs = alloc_bucket((size_type)((float)rhs._num_buckets * rhs.max_load_factor()) + 4);
+            _pairs_capacity = (size_type)((float)rhs._num_buckets * rhs.max_load_factor()) + 4;
+            _pairs = alloc_bucket(_pairs_capacity);
             _index = alloc_index(rhs._num_buckets);
             clone(rhs);
         } else {
@@ -226,6 +231,8 @@ public:
     }
 
     HashMap(HashMap&& rhs) noexcept
+        : _pair_allocator(std::move(rhs._pair_allocator))
+        , _index_allocator(std::move(rhs._index_allocator))
     {
         init(0);
         *this = std::move(rhs);
@@ -246,13 +253,56 @@ public:
             emplace(*first);
     }
 
+    explicit HashMap(const allocator_type& alloc)
+        : _pair_allocator(alloc)
+        , _index_allocator(alloc)
+    {
+        init(2);
+    }
+
+    HashMap(size_type bucket, float mlf, const allocator_type& alloc)
+        : _pair_allocator(alloc)
+        , _index_allocator(alloc)
+    {
+        init(bucket, mlf);
+    }
+
+    HashMap(const HashMap& rhs, const allocator_type& alloc)
+        : _pair_allocator(alloc)
+        , _index_allocator(alloc)
+    {
+        if (rhs.load_factor() > EMH_MIN_LOAD_FACTOR) {
+            _pairs_capacity = (size_type)((float)rhs._num_buckets * rhs.max_load_factor()) + 4;
+            _pairs = alloc_bucket(_pairs_capacity);
+            _index = alloc_index(rhs._num_buckets);
+            clone(rhs);
+        } else {
+            init(rhs._num_filled + 2, rhs.max_load_factor());
+            for (auto it = rhs.begin(); it != rhs.end(); ++it)
+                insert_unique(it->first, it->second);
+        }
+    }
+
+    HashMap(HashMap&& rhs, const allocator_type& alloc) noexcept
+        : _pair_allocator(alloc)
+        , _index_allocator(alloc)
+    {
+        init(0);
+        *this = std::move(rhs);
+    }
+
     HashMap& operator=(const HashMap& rhs)
     {
         if (this == &rhs)
             return *this;
 
+        if constexpr (PairAllocTraits::propagate_on_container_copy_assignment::value) {
+            _pair_allocator = rhs._pair_allocator;
+            _index_allocator = rhs._index_allocator;
+        }
+
         if (rhs.load_factor() < EMH_MIN_LOAD_FACTOR) {
-            clear(); free(_pairs); _pairs = nullptr;
+            clear(); dealloc_bucket(_pairs, _pairs_capacity); _pairs = nullptr; _pairs_capacity = 0;
             rehash(rhs._num_filled + 2);
             for (auto it = rhs.begin(); it != rhs.end(); ++it)
                 insert_unique(it->first, it->second);
@@ -262,9 +312,10 @@ public:
         clearkv();
 
         if (_num_buckets != rhs._num_buckets) {
-            free(_pairs); free(_index);
+            dealloc_bucket(_pairs, _pairs_capacity); dealloc_index(_index, _num_buckets);
             _index = alloc_index(rhs._num_buckets);
-            _pairs = alloc_bucket((size_type)((float)rhs._num_buckets * rhs.max_load_factor()) + 4);
+            _pairs_capacity = (size_type)((float)rhs._num_buckets * rhs.max_load_factor()) + 4;
+            _pairs = alloc_bucket(_pairs_capacity);
         }
 
         clone(rhs);
@@ -300,8 +351,8 @@ public:
     ~HashMap() noexcept
     {
         clearkv();
-        free(_pairs);
-        free(_index);
+        dealloc_bucket(_pairs, _pairs_capacity);
+        dealloc_index(_index, _num_buckets);
         _num_filled = 0;
         _index = nullptr;
         _pairs = nullptr;
@@ -313,6 +364,7 @@ public:
 //        _eq          = rhs._eq;
         _num_buckets = rhs._num_buckets;
         _num_filled  = rhs._num_filled;
+        _pairs_capacity = rhs._pairs_capacity;
         _mlf         = rhs._mlf;
         _last        = rhs._last;
         _mask        = rhs._mask;
@@ -340,6 +392,7 @@ public:
         std::swap(_index, rhs._index);
         std::swap(_num_buckets, rhs._num_buckets);
         std::swap(_num_filled, rhs._num_filled);
+        std::swap(_pairs_capacity, rhs._pairs_capacity);
         std::swap(_mask, rhs._mask);
         std::swap(_mlf, rhs._mlf);
         std::swap(_last, rhs._last);
@@ -347,6 +400,8 @@ public:
         std::swap(_ehead, rhs._ehead);
 #endif
         std::swap(_etail, rhs._etail);
+        std::swap(_pair_allocator, rhs._pair_allocator);
+        std::swap(_index_allocator, rhs._index_allocator);
     }
 
     // -------------------------------------------------------------
@@ -382,6 +437,7 @@ public:
 
     const HashT& hash_function() const { return _hasher; }
     const EqT& key_eq() const { return _eq; }
+    allocator_type get_allocator() const { return allocator_type(_pair_allocator); }
 
     void max_load_factor(float mlf)
     {
@@ -1066,20 +1122,26 @@ public:
         return true;
     }
 
-    static value_type* alloc_bucket(size_type num_buckets)
+    value_type* alloc_bucket(size_type num_buckets)
     {
-#ifdef EMH_ALLOC
-        auto new_pairs = aligned_alloc(32, (uint64_t)num_buckets * sizeof(value_type));
-#else
-        auto new_pairs = malloc((uint64_t)num_buckets * sizeof(value_type));
-#endif
-        return (value_type *)(new_pairs);
+        return PairAllocTraits::allocate(_pair_allocator, num_buckets);
     }
 
-    static Index* alloc_index(size_type num_buckets)
+    void dealloc_bucket(value_type* ptr, size_type num_buckets)
     {
-        auto new_index = malloc((EAD + (uint64_t)num_buckets) * sizeof(Index));
-        return (Index *)(new_index);
+        if (ptr)
+            PairAllocTraits::deallocate(_pair_allocator, ptr, num_buckets);
+    }
+
+    Index* alloc_index(size_type num_buckets)
+    {
+        return IndexAllocTraits::allocate(_index_allocator, num_buckets + EAD);
+    }
+
+    void dealloc_index(Index* ptr, size_type num_buckets)
+    {
+        if (ptr)
+            IndexAllocTraits::deallocate(_index_allocator, ptr, num_buckets + EAD);
     }
 
     bool reserve(size_type required_buckets) noexcept
@@ -1116,11 +1178,11 @@ public:
         return true;
     }
 
-    void rebuild(size_type num_buckets, size_type required_buckets) noexcept
+    void rebuild(size_type num_buckets, size_type required_buckets, size_type old_num_buckets) noexcept
     {
-        free(_index);
+        dealloc_index(_index, old_num_buckets);
         const auto need_size = std::max((size_type)((double)num_buckets * max_load_factor()) + 4, required_buckets + 2);
-        auto new_pairs = (value_type*)alloc_bucket(need_size);
+        auto new_pairs = alloc_bucket(need_size);
         if (is_trivially_copyable()) {
             if (_pairs)
             memcpy((char*)new_pairs, (char*)_pairs, _num_filled * sizeof(value_type));
@@ -1131,9 +1193,10 @@ public:
                     _pairs[slot].~value_type();
             }
         }
-        free(_pairs);
+        dealloc_bucket(_pairs, _pairs_capacity);
         _pairs = new_pairs;
-        _index = (Index*)alloc_index (num_buckets);
+        _pairs_capacity = need_size;
+        _index = alloc_index(num_buckets);
 
         memset((char*)_index, (int)INACTIVE, sizeof(_index[0]) * num_buckets);
         memset((char*)(_index + num_buckets), 0, sizeof(_index[0]) * EAD);
@@ -1171,9 +1234,10 @@ public:
         _last = _mask;
         num_buckets += num_buckets * EMH_PACK_TAIL / 100; //add more 5-10%
 #endif
+        auto old_num_buckets = _num_buckets;
         _num_buckets = num_buckets;
 
-        rebuild(num_buckets, (size_type)required_buckets);
+        rebuild(num_buckets, (size_type)required_buckets, old_num_buckets);
 
 #ifdef EMH_SORT
         std::sort(_pairs, _pairs + _num_filled, [this](const value_type & l, const value_type & r) {
@@ -1806,6 +1870,11 @@ private:
         }
 
 private:
+    using PairAlloc = typename std::allocator_traits<AllocT>::template rebind_alloc<value_type>;
+    using PairAllocTraits = std::allocator_traits<PairAlloc>;
+    using IndexAlloc = typename std::allocator_traits<AllocT>::template rebind_alloc<Index>;
+    using IndexAllocTraits = std::allocator_traits<IndexAlloc>;
+
     Index*    _index;
     value_type*_pairs;
 
@@ -1820,6 +1889,9 @@ private:
     size_type _ehead;
 #endif
     size_type _etail;
+    size_type _pairs_capacity;
+    PairAlloc _pair_allocator;
+    IndexAlloc _index_allocator;
 };
 } // namespace emhash
 

--- a/test/test_allocator.cpp
+++ b/test/test_allocator.cpp
@@ -1,0 +1,215 @@
+// Test custom allocator support for emhash HashMap/HashSet
+
+#include "../hash_table5.hpp"
+#include "../hash_table6.hpp"
+#include "../hash_table7.hpp"
+#include "../hash_table8.hpp"
+#include "../hash_set2.hpp"
+#include "../hash_set3.hpp"
+#include "../hash_set4.hpp"
+#include "../hash_set8.hpp"
+
+#include <cassert>
+#include <cstdio>
+#include <cstdint>
+#include <memory_resource>
+
+struct alignas(64) AlignedVal {
+    int64_t data;
+    bool operator==(const AlignedVal& o) const { return data == o.data; }
+};
+
+static void test_default_allocator()
+{
+    emhash5::HashMap<int, int> m5;
+    emhash6::HashMap<int, int> m6;
+    emhash7::HashMap<int, int> m7;
+    emhash8::HashMap<int, int> m8;
+    for (int i = 0; i < 100; i++) {
+        m5[i] = i; m6[i] = i; m7[i] = i; m8[i] = i;
+    }
+    assert(m5.size() == 100);
+    assert(m6.size() == 100);
+    assert(m7.size() == 100);
+    assert(m8.size() == 100);
+
+    auto c5 = m5; assert(c5.size() == 100 && c5[50] == 50);
+    auto c6 = m6; assert(c6.size() == 100 && c6[50] == 50);
+    auto c7 = m7; assert(c7.size() == 100 && c7[50] == 50);
+    auto c8 = m8; assert(c8.size() == 100 && c8[50] == 50);
+
+    auto v5 = std::move(c5); assert(v5.size() == 100);
+    auto v6 = std::move(c6); assert(v6.size() == 100);
+    auto v7 = std::move(c7); assert(v7.size() == 100);
+    auto v8 = std::move(c8); assert(v8.size() == 100);
+
+    printf("test_default_allocator passed\n");
+}
+
+static void test_over_aligned()
+{
+    emhash5::HashMap<int, AlignedVal> m;
+    for (int i = 0; i < 100; i++)
+        m[i] = AlignedVal{i};
+    for (int i = 0; i < 100; i++) {
+        auto it = m.find(i);
+        assert(it != m.end());
+        assert(reinterpret_cast<uintptr_t>(&it->second) % alignof(AlignedVal) == 0);
+    }
+    printf("test_over_aligned passed (alignof=%zu)\n", alignof(AlignedVal));
+}
+
+static void test_hash_sets()
+{
+    emhash2::HashSet<int> s2;
+    emhash7::HashSet<int> s3;
+    emhash9::HashSet<int> s4;
+    emhash8::HashSet<int> s8;
+    for (int i = 0; i < 100; i++) {
+        s2.insert(i); s3.insert(i); s4.insert(i); s8.insert(i);
+    }
+    assert(s2.size() == 100);
+    assert(s3.size() == 100);
+    assert(s4.size() == 100);
+    assert(s8.size() == 100);
+
+    auto c2 = s2; assert(c2.size() == 100);
+    auto v2 = std::move(c2); assert(v2.size() == 100);
+
+    printf("test_hash_sets passed\n");
+}
+
+static void test_pmr_allocator()
+{
+    using PmrAlloc = std::pmr::polymorphic_allocator<std::pair<int, int>>;
+
+    // monotonic_buffer_resource
+    {
+        char buffer[1 << 20];
+        std::pmr::monotonic_buffer_resource pool(buffer, sizeof(buffer));
+        emhash5::HashMap<int, int, std::hash<int>, std::equal_to<int>, PmrAlloc> m(2, 0.8f, PmrAlloc(&pool));
+        for (int i = 0; i < 1000; i++)
+            m[i] = i;
+        assert(m.size() == 1000);
+        assert(m[500] == 500);
+    }
+
+    // unsynchronized_pool_resource + copy
+    {
+        std::pmr::unsynchronized_pool_resource pool;
+        emhash5::HashMap<int, int, std::hash<int>, std::equal_to<int>, PmrAlloc> m(2, 0.8f, PmrAlloc(&pool));
+        for (int i = 0; i < 1000; i++)
+            m[i] = i;
+        assert(m.size() == 1000);
+
+        auto m2 = m;
+        assert(m2.size() == 1000 && m2[999] == 999);
+    }
+
+    // emhash6
+    {
+        char buffer[1 << 20];
+        std::pmr::monotonic_buffer_resource pool(buffer, sizeof(buffer));
+        emhash6::HashMap<int, int, std::hash<int>, std::equal_to<int>, PmrAlloc> m(2, 0.8f, PmrAlloc(&pool));
+        for (int i = 0; i < 1000; i++)
+            m[i] = i;
+        assert(m.size() == 1000);
+    }
+
+    // emhash7
+    {
+        char buffer[1 << 20];
+        std::pmr::monotonic_buffer_resource pool(buffer, sizeof(buffer));
+        emhash7::HashMap<int, int, std::hash<int>, std::equal_to<int>, PmrAlloc> m(2, 0.8f, PmrAlloc(&pool));
+        for (int i = 0; i < 1000; i++)
+            m[i] = i;
+        assert(m.size() == 1000);
+    }
+
+    // emhash8
+    {
+        char buffer[1 << 20];
+        std::pmr::monotonic_buffer_resource pool(buffer, sizeof(buffer));
+        emhash8::HashMap<int, int, std::hash<int>, std::equal_to<int>, PmrAlloc> m(2, 0.8f, PmrAlloc(&pool));
+        for (int i = 0; i < 1000; i++)
+            m[i] = i;
+        assert(m.size() == 1000);
+    }
+
+    // rehash
+    {
+        std::pmr::unsynchronized_pool_resource pool;
+        emhash5::HashMap<int, int, std::hash<int>, std::equal_to<int>, PmrAlloc> m(2, 0.8f, PmrAlloc(&pool));
+        for (int i = 0; i < 10000; i++)
+            m[i] = i;
+        assert(m.size() == 10000);
+        m.rehash(m.size() * 4);
+        for (int i = 0; i < 10000; i++)
+            assert(m[i] == i);
+    }
+
+    printf("test_pmr_allocator passed\n");
+}
+
+static void test_pmr_allocator_propagation()
+{
+    std::pmr::unsynchronized_pool_resource pool_a;
+    std::pmr::unsynchronized_pool_resource pool_b;
+    using PmrAlloc = std::pmr::polymorphic_allocator<std::pair<int, int>>;
+
+    // select_on_container_copy_construction: copy should use default_resource
+    {
+        emhash5::HashMap<int, int, std::hash<int>, std::equal_to<int>, PmrAlloc> src(2, 0.8f, PmrAlloc(&pool_a));
+        for (int i = 0; i < 100; i++) src[i] = i;
+
+        auto copy = src;
+        assert(copy.size() == 100 && copy[50] == 50);
+        assert(copy.get_allocator().resource() == std::pmr::get_default_resource());
+        assert(copy.get_allocator().resource() != &pool_a);
+    }
+
+    // propagate_on_container_copy_assignment: target keeps its allocator
+    {
+        emhash5::HashMap<int, int, std::hash<int>, std::equal_to<int>, PmrAlloc> a(2, 0.8f, PmrAlloc(&pool_a));
+        emhash5::HashMap<int, int, std::hash<int>, std::equal_to<int>, PmrAlloc> b(2, 0.8f, PmrAlloc(&pool_b));
+        for (int i = 0; i < 100; i++) a[i] = i;
+
+        b = a;
+        assert(b.size() == 100 && b[50] == 50);
+        assert(b.get_allocator().resource() == &pool_b);
+    }
+
+    {
+        emhash7::HashMap<int, int, std::hash<int>, std::equal_to<int>, PmrAlloc> a(2, 0.8f, PmrAlloc(&pool_a));
+        emhash7::HashMap<int, int, std::hash<int>, std::equal_to<int>, PmrAlloc> b(2, 0.8f, PmrAlloc(&pool_b));
+        for (int i = 0; i < 100; i++) a[i] = i;
+
+        b = a;
+        assert(b.size() == 100 && b[50] == 50);
+        assert(b.get_allocator().resource() == &pool_b);
+    }
+
+    {
+        emhash8::HashMap<int, int, std::hash<int>, std::equal_to<int>, PmrAlloc> a(2, 0.8f, PmrAlloc(&pool_a));
+        emhash8::HashMap<int, int, std::hash<int>, std::equal_to<int>, PmrAlloc> b(2, 0.8f, PmrAlloc(&pool_b));
+        for (int i = 0; i < 100; i++) a[i] = i;
+
+        b = a;
+        assert(b.size() == 100 && b[50] == 50);
+        assert(b.get_allocator().resource() == &pool_b);
+    }
+
+    printf("test_pmr_allocator_propagation passed\n");
+}
+
+int main()
+{
+    test_default_allocator();
+    test_over_aligned();
+    test_hash_sets();
+    test_pmr_allocator();
+    test_pmr_allocator_propagation();
+
+    printf("\nAll allocator tests passed!\n");
+    return 0;
+}


### PR DESCRIPTION
Adds a defaulted AllocT template parameter to all HashMap (5/6/7/8) and HashSet (2/3/4/8), replacing hardcoded malloc/free with allocator_traits. Fixes alignment for over-aligned value types. Backwards compatible.

Closes #39