### PR TITLE
Fix EMH_UNLIKELY on MSVC

### DIFF
--- a/include/emhash/hash_set2.hpp
+++ b/include/emhash/hash_set2.hpp
@@ -71,7 +71,7 @@
 #define EMH_UNLIKELY(condition) __builtin_expect(!!(condition), 0)
 #elif defined(_MSC_VER) && (_MSC_VER >= 1920)
 #define EMH_LIKELY(condition)   ((condition) ? ((void)__assume(condition), 1) : 0)
-#define EMH_UNLIKELY(condition) ((condition) ? 1 : ((void)__assume(!condition), 0))
+#define EMH_UNLIKELY(condition) ((condition) ? 1 : ((void)__assume(!(condition)), 0))
 #else
 #define EMH_LIKELY(condition)   (condition)
 #define EMH_UNLIKELY(condition) (condition)

--- a/include/emhash/hash_set3.hpp
+++ b/include/emhash/hash_set3.hpp
@@ -61,7 +61,7 @@
 #define EMH_UNLIKELY(condition) __builtin_expect(!!(condition), 0)
 #elif defined(_MSC_VER) && (_MSC_VER >= 1920)
 #define EMH_LIKELY(condition)   ((condition) ? ((void)__assume(condition), 1) : 0)
-#define EMH_UNLIKELY(condition) ((condition) ? 1 : ((void)__assume(!condition), 0))
+#define EMH_UNLIKELY(condition) ((condition) ? 1 : ((void)__assume(!(condition)), 0))
 #else
 #define EMH_LIKELY(condition)   (condition)
 #define EMH_UNLIKELY(condition) (condition)

--- a/include/emhash/hash_set4.hpp
+++ b/include/emhash/hash_set4.hpp
@@ -54,7 +54,7 @@
 #define EMH_UNLIKELY(condition) __builtin_expect(!!(condition), 0)
 #elif defined(_MSC_VER) && (_MSC_VER >= 1920)
 #define EMH_LIKELY(condition)   ((condition) ? ((void)__assume(condition), 1) : 0)
-#define EMH_UNLIKELY(condition) ((condition) ? 1 : ((void)__assume(!condition), 0))
+#define EMH_UNLIKELY(condition) ((condition) ? 1 : ((void)__assume(!(condition)), 0))
 #else
 #define EMH_LIKELY(condition)   (condition)
 #define EMH_UNLIKELY(condition) (condition)

--- a/include/emhash/hash_set8.hpp
+++ b/include/emhash/hash_set8.hpp
@@ -53,7 +53,7 @@
     #define EMH_UNLIKELY(condition) __builtin_expect(!!(condition), 0)
 #elif defined(_MSC_VER) && (_MSC_VER >= 1920)
     #define EMH_LIKELY(condition)   ((condition) ? ((void)__assume(condition), 1) : 0)
-    #define EMH_UNLIKELY(condition) ((condition) ? 1 : ((void)__assume(!condition), 0))
+    #define EMH_UNLIKELY(condition) ((condition) ? 1 : ((void)__assume(!(condition)), 0))
 #else
     #define EMH_LIKELY(condition)   (condition)
     #define EMH_UNLIKELY(condition) (condition)

--- a/include/emhash/hash_table5.hpp
+++ b/include/emhash/hash_table5.hpp
@@ -59,7 +59,7 @@
     #define EMH_UNLIKELY(condition) __builtin_expect(!!(condition), 0)
 #elif defined(_MSC_VER) && (_MSC_VER >= 1920)
     #define EMH_LIKELY(condition)   ((condition) ? ((void)__assume(condition), 1) : 0)
-    #define EMH_UNLIKELY(condition) ((condition) ? 1 : ((void)__assume(!condition), 0))
+    #define EMH_UNLIKELY(condition) ((condition) ? 1 : ((void)__assume(!(condition)), 0))
 #else
     #define EMH_LIKELY(condition)   (condition)
     #define EMH_UNLIKELY(condition) (condition)

--- a/include/emhash/hash_table6.hpp
+++ b/include/emhash/hash_table6.hpp
@@ -61,7 +61,7 @@
     #define EMH_UNLIKELY(condition) __builtin_expect(!!(condition), 0)
 #elif defined(_MSC_VER) && (_MSC_VER >= 1920)
     #define EMH_LIKELY(condition)   ((condition) ? ((void)__assume(condition), 1) : 0)
-    #define EMH_UNLIKELY(condition) ((condition) ? 1 : ((void)__assume(!condition), 0))
+    #define EMH_UNLIKELY(condition) ((condition) ? 1 : ((void)__assume(!(condition)), 0))
 #else
     #define EMH_LIKELY(condition)   (condition)
     #define EMH_UNLIKELY(condition) (condition)

--- a/include/emhash/hash_table7.hpp
+++ b/include/emhash/hash_table7.hpp
@@ -115,7 +115,7 @@ of resizing granularity. Ignoring variance, the expected occurrences of list siz
     #define EMH_UNLIKELY(condition) __builtin_expect(!!(condition), 0)
 #elif defined(_MSC_VER) && (_MSC_VER >= 1920)
     #define EMH_LIKELY(condition)   ((condition) ? ((void)__assume(condition), 1) : 0)
-    #define EMH_UNLIKELY(condition) ((condition) ? 1 : ((void)__assume(!condition), 0))
+    #define EMH_UNLIKELY(condition) ((condition) ? 1 : ((void)__assume(!(condition)), 0))
 #else
     #define EMH_LIKELY(condition)   (condition)
     #define EMH_UNLIKELY(condition) (condition)

--- a/include/emhash/hash_table8.hpp
+++ b/include/emhash/hash_table8.hpp
@@ -58,7 +58,7 @@
     #define EMH_UNLIKELY(condition) __builtin_expect(!!(condition), 0)
 #elif defined(_MSC_VER) && (_MSC_VER >= 1920)
     #define EMH_LIKELY(condition)   ((condition) ? ((void)__assume(condition), 1) : 0)
-    #define EMH_UNLIKELY(condition) ((condition) ? 1 : ((void)__assume(!condition), 0))
+    #define EMH_UNLIKELY(condition) ((condition) ? 1 : ((void)__assume(!(condition)), 0))
 #else
     #define EMH_LIKELY(condition)   (condition)
     #define EMH_UNLIKELY(condition) (condition)


### PR DESCRIPTION
condition must be enclosed in parentheses to avoid unsafe boolean condition.

For example:
```c++
if (EMH_UNLIKELY(j < 0))
```

was translated to:
```c++
((j < 0) ? 1 : ((void)__assume(!j < 0)), 0)
```
which is clearly not the intended condition.